### PR TITLE
feat(build): replace `maven-assembly-plugin` with `maven-shade-plugin…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 
 # Copy the built JAR from the build stage
 # The name is based on artifactId and version in pom.xml
-COPY --from=build /app/target/librarymanager-0.0.1-jar-with-dependencies.jar app.jar
+COPY --from=build /app/target/librarymanager-0.0.1.jar app.jar
 
 # Expose the port Ktor is configured to use
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -209,26 +209,22 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.7.1</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>${main.class}</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.2</version>
                 <executions>
                     <execution>
-                        <id>assemble-all</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>${main.class}</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
…` and update Dockerfile

- Switched from `maven-assembly-plugin` to `maven-shade-plugin` for better dependency shading and manifest customization.
- Updated Dockerfile to use the shaded JAR instead of the assembly JAR.