### PR TITLE
feat(book): add `countBooks` functionality in service and repository

### DIFF
--- a/src/main/kotlin/db/BookRepository.kt
+++ b/src/main/kotlin/db/BookRepository.kt
@@ -8,4 +8,5 @@ interface BookRepository {
     suspend fun findAllByUserId(userId: Long): List<Book>
     suspend fun update(id: Long, book: Book): Book?
     suspend fun delete(id: Long): Boolean
+    suspend fun countByUserId(userId: Long): Long
 }

--- a/src/main/kotlin/db/postgres/book/PSQLBookRepository.kt
+++ b/src/main/kotlin/db/postgres/book/PSQLBookRepository.kt
@@ -56,4 +56,8 @@ class PSQLBookRepository : BookRepository {
         bookDAO.delete()
         true
     }
+
+    override suspend fun countByUserId(userId: Long): Long = withTransaction {
+        BookDAO.find { BookTable.userId eq userId }.count()
+    }
 }

--- a/src/main/kotlin/service/book/BookService.kt
+++ b/src/main/kotlin/service/book/BookService.kt
@@ -11,6 +11,7 @@ interface BookServiceInterface {
     suspend fun createBook(book: Book): Book
     suspend fun updateBook(id: Long, book: Book): Book?
     suspend fun deleteBook(id: Long): Boolean
+    suspend fun countBooks(userId: Long): Long
 }
 
 class BookServiceImpl(
@@ -41,4 +42,5 @@ class BookServiceImpl(
     }
 
     override suspend fun deleteBook(id: Long): Boolean = bookRepository.delete(id)
+    override suspend fun countBooks(userId: Long): Long = bookRepository.countByUserId(userId)
 }

--- a/src/test/kotlin/db/mapping/BookDAOTest.kt
+++ b/src/test/kotlin/db/mapping/BookDAOTest.kt
@@ -9,6 +9,7 @@ import com.dw.model.dto.Author
 import com.dw.model.dto.Book
 import com.dw.plugins.configureDatabases
 import io.ktor.server.config.*
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import kotlin.test.*
@@ -259,6 +260,49 @@ class BookDAOTest {
             assertEquals(1L, dto.createdBy)
             assertEquals("2024-06-01T00:00:00", dto.modifiedOn)
             assertEquals(2L, dto.modifiedBy)
+        }
+    }
+
+    // ── count ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun testCountByUserId() {
+        val authorDAO = makeAuthor()
+        transaction {
+            BookDAO.new {
+                name = "Book 1"
+                author = authorDAO
+                isbn = "isbn-1"
+                pages = 100
+                publishedDate = "2000-01-01"
+                publisher = "Pub"
+                quantity = 1
+                userId = 10L
+            }
+            BookDAO.new {
+                name = "Book 2"
+                author = authorDAO
+                isbn = "isbn-2"
+                pages = 100
+                publishedDate = "2000-01-01"
+                publisher = "Pub"
+                quantity = 1
+                userId = 10L
+            }
+            BookDAO.new {
+                name = "Book 3"
+                author = authorDAO
+                isbn = "isbn-3"
+                pages = 100
+                publishedDate = "2000-01-01"
+                publisher = "Pub"
+                quantity = 1
+                userId = 20L
+            }
+
+            assertEquals(2, BookDAO.find { BookTable.userId eq 10L }.count())
+            assertEquals(1, BookDAO.find { BookTable.userId eq 20L }.count())
+            assertEquals(0, BookDAO.find { BookTable.userId eq 30L }.count())
         }
     }
 }

--- a/src/test/kotlin/db/postgres/book/PSQLBookRepositoryTest.kt
+++ b/src/test/kotlin/db/postgres/book/PSQLBookRepositoryTest.kt
@@ -1,0 +1,68 @@
+package db.postgres.book
+
+import com.dw.db.mapping.AuthorDAO
+import com.dw.db.mapping.AuthorTable
+import com.dw.db.mapping.BookDAO
+import com.dw.db.mapping.BookTable
+import com.dw.db.mapping.UserTable
+import com.dw.db.postgres.book.PSQLBookRepository
+import com.dw.plugins.configureDatabases
+import io.ktor.server.config.*
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.test.*
+
+class PSQLBookRepositoryTest {
+
+    private val testConfig = MapApplicationConfig(
+        "ktor.psql-database.url" to "jdbc:h2:mem:repo_book_test;DB_CLOSE_DELAY=-1",
+        "ktor.psql-database.username" to "sa",
+        "ktor.psql-database.password" to "",
+        "ktor.psql-database.driver" to "org.h2.Driver"
+    )
+
+    private val repository = PSQLBookRepository()
+
+    @BeforeTest
+    fun setup() {
+        configureDatabases(testConfig)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        transaction {
+            SchemaUtils.drop(BookTable, AuthorTable, UserTable)
+        }
+    }
+
+    private fun createAuthorAndBook(isbn: String, userId: Long) {
+        transaction {
+            val authorDAO = AuthorDAO.new {
+                name = "Author for $isbn"
+                image = "image.jpg"
+            }
+            BookDAO.new {
+                name = "Book $isbn"
+                author = authorDAO
+                this.isbn = isbn
+                pages = 100
+                publishedDate = "2020-01-01"
+                publisher = "Publisher"
+                quantity = 1
+                this.userId = userId
+            }
+        }
+    }
+
+    @Test
+    fun `countByUserId returns correct count`() = runBlocking {
+        createAuthorAndBook("isbn1", 1L)
+        createAuthorAndBook("isbn2", 1L)
+        createAuthorAndBook("isbn3", 2L)
+
+        assertEquals(2, repository.countByUserId(1L))
+        assertEquals(1, repository.countByUserId(2L))
+        assertEquals(0, repository.countByUserId(3L))
+    }
+}

--- a/src/test/kotlin/service/book/BookServiceTest.kt
+++ b/src/test/kotlin/service/book/BookServiceTest.kt
@@ -194,4 +194,17 @@ class BookServiceTest {
         val deleted = bookService.deleteBook(9999L)
         assertFalse(deleted)
     }
+
+    // ── countBooks ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `countBooks returns correct count for userId`() = runBlocking {
+        bookService.createBook(bookRequest(isbn = "isbn-c1", userId = 100L))
+        bookService.createBook(bookRequest(isbn = "isbn-c2", userId = 100L))
+        bookService.createBook(bookRequest(isbn = "isbn-c3", userId = 200L))
+
+        assertEquals(2, bookService.countBooks(100L))
+        assertEquals(1, bookService.countBooks(200L))
+        assertEquals(0, bookService.countBooks(300L))
+    }
 }


### PR DESCRIPTION
- Introduced `countBooks` method in `BookService` to retrieve book count by user ID.
- Added `countByUserId` implementation to `PSQLBookRepository` for database interaction.
- Created comprehensive test cases in `BookServiceTest`, `PSQLBookRepositoryTest`, and `BookDAOTest` to ensure accurate count retrieval.